### PR TITLE
fix: Path to `next-docs-mdx/loader-mdx`

### DIFF
--- a/.changeset/smooth-mugs-boil.md
+++ b/.changeset/smooth-mugs-boil.md
@@ -1,0 +1,5 @@
+---
+'next-docs-mdx': patch
+---
+
+Fixes import path for next-docs-mdx/loader-mdx

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -12,7 +12,7 @@
   "author": "Fuma Nama",
   "exports": {
     "./loader": "./loader.js",
-    "./loader-mdx": "./loader-mdx.js",
+    "./loader-mdx": "./dist/loader-mdx.mjs",
     "./config": {
       "import": "./dist/config.mjs",
       "types": "./dist/config.d.mts"

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -12,7 +12,7 @@
   "author": "Fuma Nama",
   "exports": {
     "./loader": "./loader.js",
-    "./loader-mdx": "./dist/loader-mdx.mjs",
+    "./loader-mdx": "./loader-mdx.js",
     "./config": {
       "import": "./dist/config.mjs",
       "types": "./dist/config.d.mts"
@@ -37,6 +37,7 @@
   },
   "files": [
     "dist/*",
+    "loader-mdx.js",
     "loader.js"
   ],
   "scripts": {


### PR DESCRIPTION
It ends up in the dist folder when bundled with tsup.